### PR TITLE
Removed perSecond helper method

### DIFF
--- a/grafana/target.js
+++ b/grafana/target.js
@@ -200,10 +200,6 @@ Target.prototype.lastWeek = function lastWeek() {
     return this.timeShift('7d');
 };
 
-Target.prototype.perSecond = function perSecond() {
-    return this.scale(0.1);
-};
-
 Target.prototype.summarize15min = function summarize15min() {
     return this.summarize('15min');
 };

--- a/test/target.js
+++ b/test/target.js
@@ -145,14 +145,6 @@ test('Target helper-method - lastWeek', function t(assert) {
     assert.end();
 });
 
-test('Target helper-method - perSecond', function t(assert) {
-    var arg = 'path.to.metric';
-    var expected = 'scale(path.to.metric, 0.1)';
-    var target = new Target(arg).perSecond().toString();
-    assert.equal(target, expected);
-    assert.end();
-});
-
 test('Target helper-method - summarize15min', function t(assert) {
     var arg = 'path.to.metric';
     var expected = 'summarize(path.to.metric, "15min")';


### PR DESCRIPTION
perSecond is already a Graphite function.  perSecond calculates the derivative
normalized w.r.t. to a second of the input time-series

The perSecond helper method was over-writing the native Graphite function.
Furthermore, the 'perSecond' helper method was wrong. That only works when your
aggregation interval is 10s, which is not the case generally. Furthermore, the
right function to what the perSecond helper method was doing is
scaleToSeconds(1).