### PR TITLE
Allow for a custom timeout

### DIFF
--- a/grafana/publish.js
+++ b/grafana/publish.js
@@ -24,7 +24,9 @@ var config = require('./config');
 var errors = require('./errors');
 
 /* eslint-disable max-statements, max-len, no-console, no-undef */
-function publish(dashboard) {
+function publish(dashboard, opts) {
+    opts = opts || {};
+    
     if (!dashboard) {
         throw errors.UnfulfilledRequirement({
             component: 'grafana.publish',
@@ -72,7 +74,7 @@ function publish(dashboard) {
         method: 'POST',
         json: createData,
         jar: j,
-        timeout: 1000
+        timeout: opts.timeout || 1000
     }, function createResponseHandler(createErr, createResp) {
         if (createErr) {
             console.log('Unable to publish dashboard: ' + createErr);

--- a/test/publish.js
+++ b/test/publish.js
@@ -208,3 +208,35 @@ test('Publish dashboard - success', function t(assert) {
     publish(dashboard);  // 201
     publish(dashboard);  // 200
 });
+
+test('Publish dashboard - success w/ custom timeout', function t(assert) {
+    config.configure({
+        cookie: cookie,
+        url: url
+    });
+    var expectedBody = {
+        dashboard: dashboard.generate(),
+        overwrite: true
+    };
+    // hijack the calls to elastic search, need to test both response codes
+    // since the initial request will return a 201 and the subsequent will
+    // return a 200.
+    nock(baseUrl)
+        .post('/dashboard')
+        .reply(201, function createdHandler(uri, requestBody) {
+            var body = JSON.parse(requestBody);
+            assert.deepEqual(body, expectedBody);
+        })
+        .post('/dashboard')
+        .reply(200, function okHandler(uri, requestBody) {
+            var body = JSON.parse(requestBody);
+            assert.deepEqual(body, expectedBody);
+            assert.end();
+        });
+    publish(dashboard, {
+        timeout: 2000
+    });  // 201
+    publish(dashboard, {
+        timeout: 2000
+    });  // 200
+});


### PR DESCRIPTION
CN1 pipeline keeps timing out because 1 second is far too short. Allow for a customizable timeout (and leave it open to expand `opts` in the future)