### PR TITLE
add ability to hide the target

### DIFF
--- a/grafana/panels/graph.js
+++ b/grafana/panels/graph.js
@@ -108,7 +108,8 @@ Graph.prototype.generate = function generate() {
 
 Graph.prototype.addTarget = function addTarget(target) {
     this.state.targets.push({
-        target: target.toString()
+        target: target.toString(),
+        hide: target.hide
     });
 };
 

--- a/grafana/target.js
+++ b/grafana/target.js
@@ -204,4 +204,9 @@ Target.prototype.summarize15min = function summarize15min() {
     return this.summarize('15min');
 };
 
+Target.prototype.hide = function hide() {
+    this.hide = true;
+    return this;
+};
+
 module.exports = Target;

--- a/grafana/templates/custom.js
+++ b/grafana/templates/custom.js
@@ -66,10 +66,11 @@ Custom.prototype._processOptions = function _processOptions() {
                 value: option
             };
         }
-        self.state.current = opt;
         newOptions.push(opt);
         newQuery.push(opt.value);
     });
+
+    self.state.current = newOptions[0];
 
     this.state.options = newOptions;
     this.state.query = newQuery.join(',');

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A grafana dashboard generator",
   "main": "index.js",
   "scripts": {
-    "fast-test": "node_modules/.bin/cached-tape -- ./test/index.js | tap-spec",
-    "test-cover": "istanbul cover --include-all-source --root ./grafana --report html --report cobertura --print detail node_modules/.bin/cached-tape -- ./test/index.js",
+    "fast-test": "node ./test/index.js | tap-spec",
+    "test-cover": "istanbul cover --include-all-source --root ./grafana --report html --report cobertura --print detail node ./test/index.js",
     "view-cover": "rm -rf ./coverage && npm run test-cover && open ./coverage/index.html",
     "test": "npm run fast-test && npm run test-cover"
   },
@@ -23,12 +23,12 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "cached-tape": "^2.0.0",
     "eslint": "^0.18.0",
     "istanbul": "^0.3.13",
     "lint-trap": "^1.0.1",
     "nock": "^2.6.0",
     "pre-commit": "^1.0.6",
-    "tap-spec": "^3.0.0"
+    "tap-spec": "^3.0.0",
+    "tape": "4.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "fast-test": "node ./test/index.js | tap-spec",
-    "test-cover": "istanbul cover --include-all-source --root ./grafana --report html --report cobertura --print detail node ./test/index.js",
+    "test-cover": "istanbul cover --include-all-source --root ./grafana --report html --report cobertura --print detail ./test/index.js",
     "view-cover": "rm -rf ./coverage && npm run test-cover && open ./coverage/index.html",
     "test": "npm run fast-test && npm run test-cover"
   },

--- a/test/annotations/graphite.js
+++ b/test/annotations/graphite.js
@@ -21,7 +21,7 @@
 'use strict';
 
 /* eslint-disable no-new */
-var test = require('cached-tape');
+var test = require('tape');
 var Graphite = require('../../grafana/annotations/graphite');
 
 var simpleGraphite = require('../fixtures/annotations/simple_graphite');

--- a/test/config.js
+++ b/test/config.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-var test = require('cached-tape');
+var test = require('tape');
 var config = require('../grafana/config');
 
 test('config extends default configuration', function t(assert) {

--- a/test/dashboard.js
+++ b/test/dashboard.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-var test = require('cached-tape');
+var test = require('tape');
 var Dashboard = require('../grafana/dashboard');
 require('../grafana/panels'); // for coverage
 

--- a/test/fixtures/override_dashboard.js
+++ b/test/fixtures/override_dashboard.js
@@ -38,8 +38,8 @@ module.exports = {
     list: [{
         allFormat: 'glob',
         current: {
-          text: 'b',
-          value: 'b'
+          text: 'a',
+          value: 'a'
         },
         datasource: null,
         includeAll: false,
@@ -57,8 +57,8 @@ module.exports = {
     }, {
         allFormat: 'glob',
         current: {
-            text: '1min',
-            value: '1min'
+            text: '30min',
+            value: '30min'
         },
         datasource: null,
         includeAll: false,

--- a/test/fixtures/panels/override_graph.js
+++ b/test/fixtures/panels/override_graph.js
@@ -59,7 +59,8 @@ module.exports = {
     stack: false,
     steppedLine: false,
     targets: [{
-        target: 'target'
+        target: 'target',
+        hide: undefined
     }],
     title: 'custom title',
     tooltip: {

--- a/test/fixtures/templates/override_custom.js
+++ b/test/fixtures/templates/override_custom.js
@@ -36,8 +36,8 @@ module.exports = {
     allFormat: 'glob',
     query: 'a,b',
     current: {
-        text: 'b',
-        value: 'b'
+        text: 'a',
+        value: 'a'
     },
     arbitraryProperty: 'foo'
 };

--- a/test/panels/graph.js
+++ b/test/panels/graph.js
@@ -21,7 +21,7 @@
 'use strict';
 
 /* eslint-disable no-new */
-var test = require('cached-tape');
+var test = require('tape');
 var Graph = require('../../grafana/panels/graph');
 
 var simpleGraph = require('../fixtures/panels/simple_graph.js');

--- a/test/panels/singlestat.js
+++ b/test/panels/singlestat.js
@@ -21,7 +21,7 @@
 'use strict';
 
 /* eslint-disable no-new */
-var test = require('cached-tape');
+var test = require('tape');
 var SingleStat = require('../../grafana/panels/singlestat');
 
 var simpleSingleStat = require('../fixtures/panels/simple_singlestat.js');

--- a/test/panels/text.js
+++ b/test/panels/text.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-var test = require('cached-tape');
+var test = require('tape');
 var Text = require('../../grafana/panels/text');
 
 var simpleText = require('../fixtures/panels/simple_text.js');

--- a/test/publish.js
+++ b/test/publish.js
@@ -20,7 +20,7 @@
 
 'use strict';
 var nock = require('nock');
-var test = require('cached-tape');
+var test = require('tape');
 var config = require('../grafana/config');
 var publish = require('../grafana/publish');
 var Dashboard = require('../grafana/dashboard');

--- a/test/row.js
+++ b/test/row.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-var test = require('cached-tape');
+var test = require('tape');
 var Row = require('../grafana/row');
 
 var simpleRow = require('./fixtures/simple_row.js');

--- a/test/target.js
+++ b/test/target.js
@@ -23,7 +23,7 @@
 'use strict';
 
 var util = require('util');
-var test = require('cached-tape');
+var test = require('tape');
 var Target = require('../grafana/target');
 
 test('Target throws exception on invalid invocation', function t(assert) {

--- a/test/target.js
+++ b/test/target.js
@@ -150,5 +150,14 @@ test('Target helper-method - summarize15min', function t(assert) {
     var expected = 'summarize(path.to.metric, "15min")';
     var target = new Target(arg).summarize15min().toString();
     assert.equal(target, expected);
+    assert.equal(target.hide, undefined);
+    assert.end();
+});
+
+test('Target can call hide()', function t(assert) {
+    var target = new Target('path.to.metric').hide();
+
+    assert.equal(target.toString(), 'path.to.metric');
+    assert.equal(target.hide, true);
     assert.end();
 });

--- a/test/templates/custom.js
+++ b/test/templates/custom.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-var test = require('cached-tape');
+var test = require('tape');
 var Custom = require('../../grafana/templates/custom');
 
 var simpleCustom = require('../fixtures/templates/simple_custom');

--- a/test/templates/query.js
+++ b/test/templates/query.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-var test = require('cached-tape');
+var test = require('tape');
 var Query = require('../../grafana/templates/query');
 
 var simpleQuery = require('../fixtures/templates/simple_query');


### PR DESCRIPTION
This allows us to have three targets, two hidden graphs and
a `divideSeries(#A,#B)` which is useful for dividing two
non trivial series.

r: @MadanThangavelu @eculver