### PR TITLE
Add support for using m3ql in templating

### DIFF
--- a/grafana/templates/query.js
+++ b/grafana/templates/query.js
@@ -57,7 +57,6 @@ function Query(query, opts) {
     };
 
     this._required = [
-        'query',
         'name',
         'datasource'
     ];
@@ -68,7 +67,8 @@ function Query(query, opts) {
         'multi',
         'multiFormat',
         'refresh',
-        'regex'
+        'regex',
+        'tag'
     ];
 
     // Override overridable values


### PR DESCRIPTION
remove required field 'query' as in m3ql, you are allow to specify tag
add 'tag' to overridable field 