### PR TITLE
Allow options overriding in Text panel and updated tests

### DIFF
--- a/grafana/panels/text.js
+++ b/grafana/panels/text.js
@@ -26,8 +26,9 @@ function Text(opts) {
     opts = opts || {};
     var self = this;
 
-    this.state = {
+    var defaults = {
         title: '',
+        id: generateGraphId(),
         error: false,
         span: 12,
         editable: true,
@@ -37,12 +38,12 @@ function Text(opts) {
         style: {},
         links: []
     };
+    this.state = defaults;
 
-    this.state.title = opts.title || this.state.title;
-    this.state.id = opts.id || generateGraphId();
-    this.state.span = opts.span || 12;
-    this.state.content = opts.content || this.state.content;
-	this.state.mode = opts.mode || this.state.mode;
+    // Overwrite defaults with custom values
+    Object.keys(opts).forEach(function eachOpt(opt) {
+        self.state[opt] = opts[opt];
+    });
 
     // finally add to row/dashboard if given
     if (opts.row && opts.dashboard) {

--- a/test/fixtures/panels/override_text.js
+++ b/test/fixtures/panels/override_text.js
@@ -28,5 +28,7 @@ module.exports = {
     "mode": "markdown",
     "content": "TEST",
     "style": {},
-    "links": []
+    "links": [],
+    "height": "100px",
+    "transparent": true
 }

--- a/test/panels/text.js
+++ b/test/panels/text.js
@@ -37,7 +37,9 @@ test('simple Text panel', function t(assert) {
 test('Text panel with overriden information', function t(assert) {
     var graph = new Text({
         span: 4,
-        content: 'TEST'
+        content: 'TEST',
+        height: '100px',
+        transparent: true
     });
     graph.state.id = overrideText.id;
 


### PR DESCRIPTION
Updating the Text panel to behave the same way as the other panel types when dealing with default options. When providing options to a Text panel they are dynamically merged so that additional options can be provided. Solves #35 