### PR TITLE
Print response headers on publish failure

### DIFF
--- a/grafana/publish.js
+++ b/grafana/publish.js
@@ -80,6 +80,7 @@ function publish(dashboard, opts) {
             console.log('Unable to publish dashboard: ' + createErr);
         } else if ([200, 201].indexOf(createResp.statusCode) === -1) {
             console.log('Unable to publish dashboard ' + state.title);
+            console.log(createResp.headers);
             console.log(createResp.body);
             console.log('Got statusCode' + createResp.statusCode);
         } else {


### PR DESCRIPTION
When publishing fails, response headers are often required to
troubleshoot the real problem, and response body is not enough.

E.g. in case of invalid credentials, one would get a 302, but the
returned HTML content is useless.