### PR TITLE
Add refId ability

### DIFF
--- a/grafana/panels/graph.js
+++ b/grafana/panels/graph.js
@@ -107,10 +107,14 @@ Graph.prototype.generate = function generate() {
 };
 
 Graph.prototype.addTarget = function addTarget(target) {
-    this.state.targets.push({
+    var targetObject = {
         target: target.toString(),
         hide: target.hide
-    });
+    };
+    if (target.ref) {
+        targetObject.refId = target.ref;
+    }
+    this.state.targets.push(targetObject);
 };
 
 module.exports = Graph;

--- a/grafana/target.js
+++ b/grafana/target.js
@@ -209,4 +209,9 @@ Target.prototype.hide = function hide() {
     return this;
 };
 
+Target.prototype.ref = function ref(id) {
+    this.ref = id;
+    return this;
+};
+
 module.exports = Target;

--- a/test/target.js
+++ b/test/target.js
@@ -161,3 +161,11 @@ test('Target can call hide()', function t(assert) {
     assert.equal(target.hide, true);
     assert.end();
 });
+
+test('Target can call ref()', function t(assert) {
+    var target = new Target('path.to.metric').ref('A');
+
+    assert.equal(target.toString(), 'path.to.metric');
+    assert.equal(target.ref, 'A');
+    assert.end();
+});


### PR DESCRIPTION
Allow Grafana reference IDs in dashboard generation so the following is possible:

```javascript
row.addPanel(new Panels.Graph({
        title: "Average Latency per Operation",
        targets: [
            new Target('some.complicated.total.metric').sumSeries().hide().ref('A'),
            new Target('some.complicated.time.metric').sumSeries().hide().ref('B'),

            // show only the division result, latency
            new Target('divideSeries(#B, #A)').ref('C')

        ]
    }));
```