### PR TITLE
Add a repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "view-cover": "rm -rf ./coverage && npm run test-cover && open ./coverage/index.html",
     "test": "npm run fast-test && npm run test-cover"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/uber/grafana-dash-gen.git"
+  },
   "keywords": [
     "grafana",
     "dashboard",


### PR DESCRIPTION
Prevents errors with

```
npm WARN package.json grafana-dash-gen@2.6.0 No repository field.
```