### PR TITLE
Update node versions to active/maintained releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
+  - "12"
+  - "14"
   - "lts/*"


### PR DESCRIPTION
According to https://nodejs.org/en/about/releases/, v8 is EOL and v10, v12, and v14 are maintained.