### PR TITLE
Fix TypeError for query templating

### DIFF
--- a/grafana/templates/query.js
+++ b/grafana/templates/query.js
@@ -54,7 +54,7 @@ function Query(query, opts) {
         refresh: false,
         multi: false,
         options: [],
-        current: null
+        current: {},
     };
 
     this._required = [

--- a/test/fixtures/templates/override_query.js
+++ b/test/fixtures/templates/override_query.js
@@ -26,7 +26,7 @@ module.exports = {
     name: 'template',
     datasource: 'datasource',
     options: [],
-    current: null,
+    current: {},
     includeAll: false,
     allFormat: 'glob',
     allValue: '*',

--- a/test/fixtures/templates/simple_query.js
+++ b/test/fixtures/templates/simple_query.js
@@ -26,7 +26,7 @@ module.exports = {
     name: 'foo',
     datasource: 'default',
     options: [],
-    current: null,
+    current: {},
     includeAll: true,
     allFormat: 'wildcard',
     allValue: null,


### PR DESCRIPTION
The current version of Grafana does not initialize `current` on a template, causing a TypeError when trying to access a property on `current` (which is null).