### PR TITLE
Remove validation for external link

### DIFF
--- a/grafana/dashboard.js
+++ b/grafana/dashboard.js
@@ -70,12 +70,6 @@ Dashboard.prototype._initRows = function _initRows(opts) {
 Dashboard.prototype._initLinks = function _initLinks(opts) {
   this.links = opts.links || [];
   this.state.links = [];
-
-  this.links.forEach(link => {
-    if (!(link instanceof ExternalLink)) {
-      throw new TypeError('links must be defined using ExternalLink')
-    }
-  })
 };
 
 Dashboard.prototype._initTemplating = function _initRows(opts) {
@@ -125,7 +119,12 @@ Dashboard.prototype.addAnnotation = function addAnnotation(annotation) {
 Dashboard.prototype.generate = function generate() {
     // Generate jsons.
     this.state.rows = this.rows.map(row => row.generate());
-    this.state.links = this.links.map(link => link.generate());
+    this.state.links = this.links.map(link => {
+      if (link instanceof ExternalLink) {
+        return link.generate()
+      }
+      return link
+    });
 
     return this.state;
 };

--- a/test/dashboard.js
+++ b/test/dashboard.js
@@ -109,7 +109,17 @@ test('Dashboard can generate correct body', function t(assert) {
         new ExternalLink({
           title: "Uber Homepage",
           url: "www.uber.com",
-        })
+        }),
+        {
+          title: "Google Homepage",
+          tooltip: "",
+          url: "www.google.com",
+          icon: "external link",
+          targetBlank: true,
+          type: "link",
+          includeVars: false,
+          keepTime: false,
+        }
       ]
     });
     var row = {
@@ -134,16 +144,19 @@ test('Dashboard can generate correct body', function t(assert) {
           type: "link",
           includeVars: false,
           keepTime: false,
+        },
+        {
+          title: "Google Homepage",
+          tooltip: "",
+          url: "www.google.com",
+          icon: "external link",
+          targetBlank: true,
+          type: "link",
+          includeVars: false,
+          keepTime: false,
         }
       ]
     }
     assert.deepEqual(json, expectedJson);
     assert.end();
-});
-
-test('Dashboard throws error if links are defined with wrong type', function t(assert) {
-  assert.throws(() => new Dashboard({
-    links: [{ title: "custom link", url: "www.wrong.com"}]
-  }), new TypeError('links must be defined using ExternalLink'))
-  assert.end();
 });


### PR DESCRIPTION
Turns out someone was able to hack the `links` parameter so we need to remove the validation for backwards compatibility