### PR TITLE
Default to All value if includeAll

### DIFF
--- a/test/fixtures/override_dashboard.js
+++ b/test/fixtures/override_dashboard.js
@@ -18,8 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-var ExternalLink = require('../../grafana/external-link')
-
 'use strict';
 module.exports = {
   id: null,
@@ -45,6 +43,7 @@ module.exports = {
         },
         datasource: null,
         includeAll: false,
+        allValue: '',
         name: 'myvar',
         options: [{
             text: 'a',
@@ -64,6 +63,7 @@ module.exports = {
         },
         datasource: null,
         includeAll: false,
+        allValue: '',
         name: 'smoothing',
         options: [{
             text: '30min',

--- a/test/fixtures/templates/override_custom.js
+++ b/test/fixtures/templates/override_custom.js
@@ -33,6 +33,7 @@ module.exports = {
     datasource: null,
     'refresh_on_load': false,
     includeAll: false,
+    allValue: '',
     allFormat: 'glob',
     query: 'a,b',
     current: {

--- a/test/fixtures/templates/override_custom_text_value.js
+++ b/test/fixtures/templates/override_custom_text_value.js
@@ -30,6 +30,7 @@ module.exports = {
     datasource: null,
     'refresh_on_load': false,
     includeAll: false,
+    allValue: '',
     allFormat: 'glob',
     query: 'myValue',
     current: {

--- a/test/fixtures/templates/simple_custom.js
+++ b/test/fixtures/templates/simple_custom.js
@@ -25,6 +25,7 @@ module.exports = {
     datasource: null,
     refresh_on_load: false,
     includeAll: false,
+    allValue: '',
     allFormat: 'glob',
     query: null,
     current: null

--- a/test/templates/custom.js
+++ b/test/templates/custom.js
@@ -94,5 +94,57 @@ test('Custom template overwrites default state', function t(assert) {
         arbitraryProperty: 'foo'
     });
     assert.equal(customTemplate.state.includeAll, true);
+    assert.equal(customTemplate.state.allValue, '')
+
+    var customWithAllValue = new Custom({
+      includeAll: true,
+      arbitraryProperty: 'foo',
+      allValue: 'grafana',
+    });
+    assert.equal(customWithAllValue.state.includeAll, true);
+    assert.equal(customWithAllValue.state.allValue, 'grafana')
+
+    var allIsDefault = new Custom({
+      includeAll: true,
+      arbitraryProperty: 'foo',
+      options: [{ text: 'grafana', value: 'grafana' }]
+    });
+    assert.equal(allIsDefault.state.includeAll, true);
+    assert.equal(allIsDefault.state.allValue, '')
+    assert.equal(allIsDefault.state.current.text, "All");
+    assert.equal(allIsDefault.state.current.value, '');
+
     assert.end();
 });
+
+test('Custom template supports custom default', function t(assert) {
+  const defaultOption = { text: 'dash-gen', value: 'dash-gen' }
+  var definedDefault = new Custom({
+    includeAll: true,
+    defaultValue: defaultOption.value,
+    options: [{ text: 'grafana', value: 'grafana' }, defaultOption]
+  });
+  assert.equal(definedDefault.state.includeAll, true);
+  assert.equal(definedDefault.state.allValue, '')
+  assert.equal(definedDefault.state.current, defaultOption);
+
+  assert.throws(
+    () => new Custom({
+      includeAll: true,
+      defaultValue: defaultOption.value,
+      options: [{ text: 'grafana', value: 'grafana' }]
+    }),
+    new SyntaxError("default value not found in options list"),
+  );
+
+  assert.throws(
+    () => new Custom({
+      includeAll: true,
+      defaultValue: defaultOption.value,
+    }),
+    new SyntaxError("cannot define default value without any options"),
+  );
+
+  assert.end();
+});
+


### PR DESCRIPTION
Template.Custom was always defaulting to the first item in the options list, which doesn't make much sense if `includeAll` is true, and especially doesn't make sense if an `allValue` is provided.

Set the default `current` to `All` if `includeAll` is true or unless otherwise specified by the new `defaultValue` param