### PR TITLE
Use Refresh in Templates.Custom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-dash-gen",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-dash-gen",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "A grafana dashboard generator",
   "main": "index.js",
   "scripts": {

--- a/test/fixtures/override_dashboard.js
+++ b/test/fixtures/override_dashboard.js
@@ -53,6 +53,7 @@ module.exports = {
             value: 'b'
         }],
         query: 'a,b',
+        refresh: 1,
         'refresh_on_load': false,
         type: 'custom'
     }, {
@@ -81,6 +82,7 @@ module.exports = {
             value: '1min'
         }],
         query: '30min,10min,5min,2min,1min',
+        refresh: 1,
         'refresh_on_load': false,
         type: 'custom'
     }]

--- a/test/fixtures/templates/override_custom.js
+++ b/test/fixtures/templates/override_custom.js
@@ -31,6 +31,7 @@ module.exports = {
         value: 'b'
     }],
     datasource: null,
+    refresh: 1,
     'refresh_on_load': false,
     includeAll: false,
     allValue: '',

--- a/test/fixtures/templates/override_custom_text_value.js
+++ b/test/fixtures/templates/override_custom_text_value.js
@@ -28,6 +28,7 @@ module.exports = {
         value: 'myValue'
     }],
     datasource: null,
+    refresh: 1,
     'refresh_on_load': false,
     includeAll: false,
     allValue: '',

--- a/test/fixtures/templates/simple_custom.js
+++ b/test/fixtures/templates/simple_custom.js
@@ -23,6 +23,7 @@ module.exports = {
     type: 'custom',
     options: [],
     datasource: null,
+    refresh: 1,
     refresh_on_load: false,
     includeAll: false,
     allValue: '',

--- a/test/templates/custom.js
+++ b/test/templates/custom.js
@@ -95,8 +95,7 @@ test('Custom template overwrites default state', function t(assert) {
     });
     assert.equal(customTemplate.state.includeAll, true);
     assert.equal(customTemplate.state.allValue, '');
-    assert.equal(customTemplate.state.current.text, "All");
-    assert.equal(customTemplate.state.current.value, '$__all');
+    assert.equal(customTemplate.state.current, null);
 
     var customWithAllValue = new Custom({
       includeAll: true,
@@ -104,6 +103,7 @@ test('Custom template overwrites default state', function t(assert) {
       allValue: 'grafana',
     });
     assert.equal(customWithAllValue.state.includeAll, true);
+    assert.equal(customWithAllValue.state.current, null);
     assert.equal(customWithAllValue.state.allValue, 'grafana')
 
     var allIsDefault = new Custom({
@@ -113,8 +113,15 @@ test('Custom template overwrites default state', function t(assert) {
     });
     assert.equal(allIsDefault.state.includeAll, true);
     assert.equal(allIsDefault.state.allValue, '')
-    assert.equal(allIsDefault.state.current.text, "All");
-    assert.equal(allIsDefault.state.current.value, '$__all');
+    assert.equal(allIsDefault.state.current, null);
+
+    var firstIsDefault = new Custom({
+      arbitraryProperty: 'foo',
+      options: [{ text: 'grafana', value: 'grafana' }]
+    });
+    assert.equal(firstIsDefault.state.includeAll, false);
+    assert.equal(firstIsDefault.state.allValue, '')
+    assert.equal(firstIsDefault.state.current, firstIsDefault.state.options[0]);
 
     assert.end();
 });
@@ -144,7 +151,7 @@ test('Custom template supports custom default', function t(assert) {
       includeAll: true,
       defaultValue: defaultOption.value,
     }),
-    new SyntaxError("default value not found in options list"),
+    new SyntaxError("cannot define default value without any options"),
   );
 
   assert.throws(


### PR DESCRIPTION
Creating the `All` variable in Templates.Custom is inconsistent based
on different use cases. The only thing that seems to work is to set the
refresh variable so that Grafana can refresh the list when the dashboard originally loads