### PR TITLE
Set current when includeAll is true

### DIFF
--- a/grafana/templates/custom.js
+++ b/grafana/templates/custom.js
@@ -92,7 +92,7 @@ Custom.prototype._processOptions = function _processOptions() {
         throw new SyntaxError("default value not found in options list")
       }
       this.state.current = defaultOption
-    } else if (!this.state.current && !this.state.includeAll) {
+    } else if (!this.state.current) {
       this.state.current = newOptions[0];
     }
 

--- a/test/templates/custom.js
+++ b/test/templates/custom.js
@@ -106,15 +106,6 @@ test('Custom template overwrites default state', function t(assert) {
     assert.equal(customWithAllValue.state.current, null);
     assert.equal(customWithAllValue.state.allValue, 'grafana')
 
-    var allIsDefault = new Custom({
-      includeAll: true,
-      arbitraryProperty: 'foo',
-      options: [{ text: 'grafana', value: 'grafana' }]
-    });
-    assert.equal(allIsDefault.state.includeAll, true);
-    assert.equal(allIsDefault.state.allValue, '')
-    assert.equal(allIsDefault.state.current, null);
-
     var firstIsDefault = new Custom({
       arbitraryProperty: 'foo',
       options: [{ text: 'grafana', value: 'grafana' }]


### PR DESCRIPTION
We are observing that grafana dashboards are missing variables for graphana version 9.3.8. It seems like the problem is for custom templates where includeAll is set to true but no current value is set. This change sets sets current to the first value if no default value and no current is set.