### PR TITLE
Set the first option as current when none is given

### DIFF
--- a/grafana/templates/custom.js
+++ b/grafana/templates/custom.js
@@ -92,7 +92,7 @@ Custom.prototype._processOptions = function _processOptions() {
         throw new SyntaxError("default value not found in options list")
       }
       this.state.current = defaultOption
-    } else if (!this.state.current && !this.state.includeAll) {
+    } else if (!this.state.current) {
       this.state.current = newOptions[0];
     }
 

--- a/test/templates/custom.js
+++ b/test/templates/custom.js
@@ -106,14 +106,14 @@ test('Custom template overwrites default state', function t(assert) {
     assert.equal(customWithAllValue.state.current, null);
     assert.equal(customWithAllValue.state.allValue, 'grafana')
 
-    var allIsDefault = new Custom({
+    var firstIsDefaultWithAll = new Custom({
       includeAll: true,
       arbitraryProperty: 'foo',
       options: [{ text: 'grafana', value: 'grafana' }]
     });
-    assert.equal(allIsDefault.state.includeAll, true);
-    assert.equal(allIsDefault.state.allValue, '')
-    assert.equal(allIsDefault.state.current, null);
+    assert.equal(firstIsDefaultWithAll.state.includeAll, true);
+    assert.equal(firstIsDefaultWithAll.state.allValue, '')
+    assert.equal(firstIsDefaultWithAll.state.current, firstIsDefaultWithAll.state.options[0]);
 
     var firstIsDefault = new Custom({
       arbitraryProperty: 'foo',


### PR DESCRIPTION
When starting to use grafana varsion 9.3.8 we have issues when the templates do not have the current value set. This was prev. the case when includeAll was true and not current or defaultvalue was set. In this diff we ensure that current is always set