### PR TITLE
Explicitly list out files included in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,16 @@
     "tap-arc": "^0.3.5",
     "tape": "^5.6.6"
   },
+  "files": [
+    "CHANGELOG.md",
+    "CONTRIBUTION.md",
+    "LICENSE",
+    "README.md",
+    "example.js",
+    "grafana",
+    "index.js",
+    "package.json"
+  ],
   "engines": {
     "node": ">=10"
   }


### PR DESCRIPTION
This slims down the generated package from 270kB to 15kB by removing test files and grafana.png.