### PR TITLE
Use an empty object instead of null to avoid type issues

### DIFF
--- a/grafana/templates/custom.js
+++ b/grafana/templates/custom.js
@@ -26,7 +26,7 @@ function Custom(opts) {
     opts = opts || {};
     this.state = {
         allFormat: 'glob',
-        current: null,
+        current: {},
         datasource: null,
         includeAll: false,
         allValue: '',
@@ -92,7 +92,7 @@ Custom.prototype._processOptions = function _processOptions() {
         throw new SyntaxError("default value not found in options list")
       }
       this.state.current = defaultOption
-    } else if (!this.state.current && !this.state.includeAll) {
+    } else if ((!this.state.current || Object.keys(this.state.current).length === 0) && !this.state.includeAll) {
       this.state.current = newOptions[0];
     }
 

--- a/test/fixtures/templates/simple_custom.js
+++ b/test/fixtures/templates/simple_custom.js
@@ -29,5 +29,5 @@ module.exports = {
     allValue: '',
     allFormat: 'glob',
     query: null,
-    current: null
+    current: {}
 }

--- a/test/templates/custom.js
+++ b/test/templates/custom.js
@@ -95,7 +95,7 @@ test('Custom template overwrites default state', function t(assert) {
     });
     assert.equal(customTemplate.state.includeAll, true);
     assert.equal(customTemplate.state.allValue, '');
-    assert.equal(customTemplate.state.current, null);
+    assert.deepEqual(customTemplate.state.current, {});
 
     var customWithAllValue = new Custom({
       includeAll: true,
@@ -103,7 +103,7 @@ test('Custom template overwrites default state', function t(assert) {
       allValue: 'grafana',
     });
     assert.equal(customWithAllValue.state.includeAll, true);
-    assert.equal(customWithAllValue.state.current, null);
+    assert.deepEqual(customTemplate.state.current, {});
     assert.equal(customWithAllValue.state.allValue, 'grafana')
 
     var allIsDefault = new Custom({
@@ -113,7 +113,7 @@ test('Custom template overwrites default state', function t(assert) {
     });
     assert.equal(allIsDefault.state.includeAll, true);
     assert.equal(allIsDefault.state.allValue, '')
-    assert.equal(allIsDefault.state.current, null);
+    assert.deepEqual(customTemplate.state.current, {});
 
     var firstIsDefault = new Custom({
       arbitraryProperty: 'foo',


### PR DESCRIPTION
For compatibility with grafana v9: https://github.com/grafana/grafana/commit/3339d13a45ba1011bfb2cf3d4af6cf1935dec753