### PR TITLE
Set refresh: 0 by default in custom templates

### DIFF
--- a/grafana/templates/custom.js
+++ b/grafana/templates/custom.js
@@ -33,7 +33,7 @@ function Custom(opts) {
         name: 'template',
         options: [],
         query: null,
-        refresh: 1,
+        refresh: 0,
         'refresh_on_load': false,
         type: 'custom'
     };

--- a/test/fixtures/override_dashboard.js
+++ b/test/fixtures/override_dashboard.js
@@ -53,7 +53,7 @@ module.exports = {
             value: 'b'
         }],
         query: 'a,b',
-        refresh: 1,
+        refresh: 0,
         'refresh_on_load': false,
         type: 'custom'
     }, {
@@ -82,7 +82,7 @@ module.exports = {
             value: '1min'
         }],
         query: '30min,10min,5min,2min,1min',
-        refresh: 1,
+        refresh: 0,
         'refresh_on_load': false,
         type: 'custom'
     }]

--- a/test/fixtures/templates/override_custom.js
+++ b/test/fixtures/templates/override_custom.js
@@ -31,7 +31,7 @@ module.exports = {
         value: 'b'
     }],
     datasource: null,
-    refresh: 1,
+    refresh: 0,
     'refresh_on_load': false,
     includeAll: false,
     allValue: '',

--- a/test/fixtures/templates/override_custom_text_value.js
+++ b/test/fixtures/templates/override_custom_text_value.js
@@ -28,7 +28,7 @@ module.exports = {
         value: 'myValue'
     }],
     datasource: null,
-    refresh: 1,
+    refresh: 0,
     'refresh_on_load': false,
     includeAll: false,
     allValue: '',

--- a/test/fixtures/templates/simple_custom.js
+++ b/test/fixtures/templates/simple_custom.js
@@ -23,7 +23,7 @@ module.exports = {
     type: 'custom',
     options: [],
     datasource: null,
-    refresh: 1,
+    refresh: 0,
     refresh_on_load: false,
     includeAll: false,
     allValue: '',

--- a/test/templates/custom.js
+++ b/test/templates/custom.js
@@ -103,7 +103,7 @@ test('Custom template overwrites default state', function t(assert) {
       allValue: 'grafana',
     });
     assert.equal(customWithAllValue.state.includeAll, true);
-    assert.deepEqual(customTemplate.state.current, {});
+    assert.deepEqual(customWithAllValue.state.current, {});
     assert.equal(customWithAllValue.state.allValue, 'grafana')
 
     var allIsDefault = new Custom({
@@ -113,7 +113,7 @@ test('Custom template overwrites default state', function t(assert) {
     });
     assert.equal(allIsDefault.state.includeAll, true);
     assert.equal(allIsDefault.state.allValue, '')
-    assert.deepEqual(customTemplate.state.current, {});
+    assert.deepEqual(allIsDefault.state.current, {});
 
     var firstIsDefault = new Custom({
       arbitraryProperty: 'foo',


### PR DESCRIPTION
Setting refresh to 1 by default (#87) was found to break other dashboards relying on static variable options. Changing to 0.